### PR TITLE
Set BPM thread safely

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required (VERSION 3.16..3.22)
 project (juce_audio_plugin VERSION 0.0.1)
 
-set (juce_dir "$ENV{HOME}/Documents/Code/JUCE/")
+# set (juce_dir "$ENV{HOME}/Documents/Code/JUCE/")
+set (juce_dir "C:/develop/juce_clap_host/libs/JUCE")
 add_subdirectory (${juce_dir} "${PROJECT_BINARY_DIR}/juce")
 
 option (JUCE_BUILD_EXTRAS "Build JUCE Extras" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required (VERSION 3.16..3.22)
 project (juce_audio_plugin VERSION 0.0.1)
 
-# set (juce_dir "$ENV{HOME}/Documents/Code/JUCE/")
-set (juce_dir "C:/develop/juce_clap_host/libs/JUCE")
+set (juce_dir "$ENV{HOME}/Documents/Code/JUCE/")
+# set (juce_dir "C:/develop/juce_clap_host/libs/JUCE")
 add_subdirectory (${juce_dir} "${PROJECT_BINARY_DIR}/juce")
 
 option (JUCE_BUILD_EXTRAS "Build JUCE Extras" OFF)

--- a/shared/standalone/StandaloneFilterApp.h
+++ b/shared/standalone/StandaloneFilterApp.h
@@ -90,7 +90,12 @@ public:
 
     //==============================================================================
     MidiKeyboardState& getMidiState()                { return midiState; }
-    AudioPlayHead::PositionInfo& getPlayHeadInfo()   { return player.getPlayHeadInfo(); }
+    void SetBPM(double bpm)
+    {
+        // player sets this thread safely, using a lock, though...
+        player.setBPM(bpm);
+    }
+    
 
     //==============================================================================
     AudioProcessorEditor* createEditor() const
@@ -165,7 +170,10 @@ public:
         tempoSlider.setValue (120.0);
         tempoSlider.setSkewFactorFromMidPoint (120.0);
         tempoSlider.setTextValueSuffix(" BPM");
-        tempoSlider.onValueChange = [&] () { pluginProcessor->getPlayHeadInfo().setBpm (tempoSlider.getValue()); };
+        tempoSlider.onValueChange = [&] () 
+        { 
+            pluginProcessor->SetBPM(tempoSlider.getValue());
+        };
 
         editorComponent.reset (new PluginEditorComponent 
         (


### PR DESCRIPTION
Not my preferred way to handle it, but safer than directly poking into the playhead position info without any thread synchronization.